### PR TITLE
Remove invalid validation for `ackWithFailureAfterMaxRetries` with `deadLetterStore` enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ public type StoreListenerConfiguration record {|
     # The interval in seconds between retries for processing a message
     decimal retryInterval = 1;
     # If true, the message will be acknowledged with a failure after the maximum number of retries.
-    boolean ackWithFailureAfterMaxRetries = false;
+    # Else the message will be acknowledged with success
+    boolean ackWithFailureAfterMaxRetries = true;
     # An optional message store to store messages that could not be processed after the maximum 
-    # number of retries. When set, `ackWithFailureAfterMaxRetries` will be ignored
+    # number of retries. On successful storage, the message will be acknowledged with success
     Store deadLetterStore?;
 |};
 ```

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -74,9 +74,10 @@ public type StoreListenerConfiguration record {|
     # The interval in seconds between retries for processing a message
     decimal retryInterval = 1;
     # If true, the message will be acknowledged as failed after the maximum number of retries.
-    boolean ackWithFailureAfterMaxRetries = false;
+    # Else the message will be acknowledged with success
+    boolean ackWithFailureAfterMaxRetries = true;
     # An optional message store to store messages that could not be processed after the maximum 
-    # number of retries. When set, `ackWithFailureAfterMaxRetries` will be ignored
+    # number of retries. On successful storage, the message will be acknowledged with success
     Store deadLetterStore?;
 |};
 ```

--- a/ballerina/tests/msg_store_listener_tests.bal
+++ b/ballerina/tests/msg_store_listener_tests.bal
@@ -307,7 +307,7 @@ listener StoreListener customDeadLetterStoreListenerWithDrop = new (
     maxRetries = 1,
     retryInterval = 2,
     deadLetterStore = customDeadLetterStore,
-    ackWithFailureAfterMaxRetries = true
+    ackWithFailureAfterMaxRetries = false
 );
 
 listener StoreListener customDeadLetterStoreListenerWithoutDrop = new (
@@ -316,7 +316,7 @@ listener StoreListener customDeadLetterStoreListenerWithoutDrop = new (
     maxRetries = 1,
     retryInterval = 2,
     deadLetterStore = customDeadLetterStore,
-    ackWithFailureAfterMaxRetries = false
+    ackWithFailureAfterMaxRetries = true
 );
 
 service on customDeadLetterStoreListenerWithDrop, customDeadLetterStoreListenerWithoutDrop {

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -86,12 +86,13 @@ type StoreListenerConfiguration record {|
     decimal pollingInterval = 1;
     int maxRetries = 3;
     decimal retryInterval = 1;
-    boolean ackWithFailureAfterMaxRetries = false;
+    boolean ackWithFailureAfterMaxRetries = true;
     Store deadLetterStore?;
 |};
 ```
 
 **Key Features:**
+
 - Configurable polling, retry, and DLQ behavior
 - Attachable service for message processing
 - Graceful and immediate stop operations


### PR DESCRIPTION
## Purpose

The boolean value for `ackWithFailureAfterMaxRetries` configures how the message should be handled during the execution.

If the execution is successful (`onMessage` function returns a nil value), then the message will be acknowledged with success.

If the execution fails after maximum retries, then based on the `ackWithFailureAfterMaxRetries` value, the message will be acknowledged.
- If `ackWithFailureAfterMaxRetries` is set to true, the message will be acknowledged with failure (Default)
- If `ackWithFailureAfterMaxRetries` is set to false, the message will be acknowledged with success

If the `deadLetterStore` store is configured, first we try to store the failed message in the store
- If the storage is successful, the message will be acknowledged with success
- If the storage is not successful, the acknowledgement is based in the `ackWithFailureAfterMaxRetries` value

## Examples

N/A

## Checklist

- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] Added tests
- [ ] ~Updated the spec~
